### PR TITLE
FIX HttpCrawler: add site map include parameter when creating HttpQueueP...

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/crawler/HttpCrawler.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/crawler/HttpCrawler.java
@@ -163,7 +163,7 @@ public class HttpCrawler extends AbstractCrawler {
         HttpCrawlData httpData = (HttpCrawlData) crawlData;
         HttpQueuePipelineContext context = new HttpQueuePipelineContext(
                 this, crawlDataStore, httpData);
-        new HttpQueuePipeline().execute(context);
+        new HttpQueuePipeline(!getCrawlerConfig().isIgnoreSitemap()).execute(context);
     }
 
     @Override


### PR DESCRIPTION
For previous discussion: https://github.com/Norconex/collector-http/pull/65

Site map is not always read by collector-http 2.0.2

