### PR TITLE
FIX #164 Crawl fails when canonical link is escaped

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/url/impl/GenericCanonicalLinkDetector.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/url/impl/GenericCanonicalLinkDetector.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.http.client.utils.URIUtils;
 
 import com.norconex.collector.http.doc.HttpMetadata;
+import com.norconex.collector.http.pipeline.committer.HttpCommitterPipeline;
 import com.norconex.collector.http.url.ICanonicalLinkDetector;
 import com.norconex.commons.lang.EqualsUtil;
 import com.norconex.commons.lang.config.ConfigurationUtil;
@@ -43,6 +44,9 @@ import com.norconex.commons.lang.file.ContentType;
 import com.norconex.commons.lang.io.TextReader;
 import com.norconex.commons.lang.unit.DataUnit;
 import com.norconex.commons.lang.xml.EnhancedXMLStreamWriter;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 
 /**
  * <p>Generic canonical link detector. It detects links from the HTTP headers
@@ -89,6 +93,9 @@ import com.norconex.commons.lang.xml.EnhancedXMLStreamWriter;
 public class GenericCanonicalLinkDetector 
         implements ICanonicalLinkDetector, IXMLConfigurable {
 
+    private static final Logger LOG = 
+        LogManager.getLogger(HttpCommitterPipeline.class);
+    
     private static final ContentType[] DEFAULT_CONTENT_TYPES = 
             new ContentType[] {
         ContentType.HTML,
@@ -180,7 +187,8 @@ public class GenericCanonicalLinkDetector
         if (link.matches("^https{0,1}://")) {
             return link;
         }
-        return URIUtils.resolve(URI.create(pagerReference), link).toString();
+        return URIUtils.resolve(URI.create(pagerReference), 
+                StringEscapeUtils.unescapeHtml4(link)).toString();
     }
 
     @Override

--- a/norconex-collector-http/src/test/java/com/norconex/collector/http/url/impl/GenericCanonicalLinkDetectorTest.java
+++ b/norconex-collector-http/src/test/java/com/norconex/collector/http/url/impl/GenericCanonicalLinkDetectorTest.java
@@ -77,6 +77,24 @@ public class GenericCanonicalLinkDetectorTest {
     }
     
     @Test
+    public void testEscapedCanonicalUrl() throws IOException {
+        String reference = "http://www.test.te.com/web";
+        GenericCanonicalLinkDetector d = new GenericCanonicalLinkDetector();
+        String escapedCanonicalUrl = "https&#x3a;&#x2f;&#x2f;test&#x2e;kaffe&#x2e;se&#x2f;web";
+        String unescapedCanonicalUrl = "https://test.kaffe.se/web";
+        String url = null;
+        
+        // Valid link tag
+        String contentValid = "<html><head><title>Test</title>\n"
+                + "<link rel=\"canonical\"\n href=\"\n" + escapedCanonicalUrl 
+                + "\" />\n"
+                + "</head><body>Nothing of interest in body</body></html>";
+        url = d.detectFromContent(reference,  new ByteArrayInputStream(
+                contentValid.getBytes()), ContentType.HTML);
+        Assert.assertEquals(unescapedCanonicalUrl, url);
+    }
+    
+    @Test
     public void testWriteRead() throws IOException {
         GenericCanonicalLinkDetector d = new GenericCanonicalLinkDetector();
         d.setContentTypes(ContentType.HTML, ContentType.TEXT);


### PR DESCRIPTION
Unescape when parsing canonical links.