### PR TITLE
Correctly resolve relative <base href>s against the document's address

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/url/impl/GenericLinkExtractor.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/url/impl/GenericLinkExtractor.java
@@ -20,6 +20,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -314,8 +316,14 @@ public class GenericLinkExtractor implements ILinkExtractor, IXMLConfigurable {
         if (firstChunk) {
             Matcher matcher = BASE_HREF_PATTERN.matcher(txt);
             if (matcher.find()) {
-                String reference = matcher.group(2);
-                ref = new Referer(reference);
+                try {
+                    String reference = matcher.group(2);
+                    URI oldRefererURI = new URI(referer.url);
+                    URI baseHrefURI = new URI(reference);
+                    ref = new Referer(oldRefererURI.resolve(baseHrefURI).toString());
+                } catch (URISyntaxException ex) {
+                    LOG.warn("Could not parse and resolve <base href='…'> ("+ matcher.group(2) +"): "+ ex);
+                }
             }
         }
         return ref;

--- a/norconex-collector-http/src/test/java/com/norconex/collector/http/url/impl/LinkExtractorTest.java
+++ b/norconex-collector-http/src/test/java/com/norconex/collector/http/url/impl/LinkExtractorTest.java
@@ -130,6 +130,7 @@ public class LinkExtractorTest {
     public void testGenericBaseHrefLinkExtractor() throws IOException {
         GenericLinkExtractor ex = new GenericLinkExtractor();
         testBaseHrefLinkExtraction(ex);
+        testRelativeBaseHrefLinkExtraction(ex);
     }
     @Test
     public void testTikaBaseHrefLinkExtractor() throws IOException {
@@ -152,6 +153,30 @@ public class LinkExtractorTest {
         
         InputStream is = 
                 getClass().getResourceAsStream("LinkBaseHrefTest.html");
+        Set<Link> links = extractor.extractLinks(
+                is, docURL, ContentType.HTML);
+        IOUtils.closeQuietly(is);
+        for (String expectedURL : expectedURLs) {
+            assertTrue("Could not find expected URL: " + expectedURL, 
+                    contains(links, expectedURL));
+        }
+        Assert.assertEquals("Invalid number of links extracted.", 
+                expectedURLs.length, links.size());
+    }
+    private void testRelativeBaseHrefLinkExtraction(ILinkExtractor extractor) 
+            throws IOException {
+        String docURL = "http://www.example.com/test/relative/"
+                + "LinkRelativeBaseHrefTest.html";
+
+        // All these must be found
+        String[] expectedURLs = {
+                "http://www.example.com/test/relative/blah.html?param=value",
+                "http://www.example.com/d/e/f.html",
+                "http://www.anotherhost.com/k/l/m.html",
+        };
+        
+        InputStream is = 
+                getClass().getResourceAsStream("LinkRelativeBaseHrefTest.html");
         Set<Link> links = extractor.extractLinks(
                 is, docURL, ContentType.HTML);
         IOUtils.closeQuietly(is);

--- a/norconex-collector-http/src/test/java/com/norconex/collector/http/url/impl/LinkRelativeBaseHrefTest.html
+++ b/norconex-collector-http/src/test/java/com/norconex/collector/http/url/impl/LinkRelativeBaseHrefTest.html
@@ -1,0 +1,28 @@
+<!-- 
+   Copyright 2015 Norconex Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ -->
+<html>
+<head>
+  <title>ILinkExtractor tests</title>
+  <meta charset="UTF-8">
+  <base href="blah.html" />
+  <meta name="description" content="a test page">
+</head>
+<body>
+<a href="?param=value">Relative to base URL</a>
+<a href="/d/e/f.html">Relative to root</a>
+<a href="http://www.anotherhost.com/k/l/m.html">Absolute to another domain</a>
+</body>
+</html>


### PR DESCRIPTION
### Given

Given a document http://example.com/myself.html which defines a relative `<base href>` and then further includes a relative link:


```html
<!DOCTYPE html>
<html>
  <head>
    <base href="myself.html">
  </head>

  <body>
    <a href="?param=value">Relative link</a>
  </body>
</html>
```

### Expected

The link extractor should resolve the relative link against the relative base, which in turn should be resolved against the absolute URL of the document: `http://example.com/myself.html?param=value`.

### Actual

The link extractor "blindly" appends the link to the base to the filename: `myself.htmlmyself.html?param=value`.

### Proposed solution

Please see attached for a test demonstrating the problem and a proposed patch that should not only solve the issue at hand but also make the entire <base href> parsing process more robust overall by relying on Java's built-in URI parser and resolver capabilities.

### Rationale

Not only have I seen this in the wild, but it is in fact supported by the HTML specs:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base:
> The base URL to be used throughout the document for relative URL addresses. If this attribute is specified, this element must come before any other elements with attributes whose values are URLs. **Absolute and relative URLs are allowed.**

https://dev.w3.org/html5/spec-preview/urls.html#document-base-url:
> The document base URL of a Document object is the absolute URL obtained by running these substeps:
> 1. **Let _fallback base url_ be the document's address.**
> 2. If fallback base url is about:blank, and the Document's browsing context has a creator browsing context, then let fallback base url be the document base URL of the creator Document instead.
> 3. If the Document is an iframe srcdoc document, then let fallback base url be the document base URL of the Document's browsing context's browsing context container's Document instead.
> 4. If there is no **base element that has an href attribute**, then the document base URL is fallback base url; abort these steps. Otherwise, **let _url_ be the value of the href attribute of the first such element**.
> 5. **Resolve _url_ relative to _fallback base url_** (thus, the base href attribute isn't affected by xml:base attributes).
> 6. The document base URL is the result of the previous step if it was successful; otherwise it is fallback base url.
