### PR TITLE
Add nofollow.regexUrl to GenericLinkExtractor

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/pipeline/importer/LinkExtractorStage.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/pipeline/importer/LinkExtractorStage.java
@@ -14,7 +14,6 @@
  */
 package com.norconex.collector.http.pipeline.importer;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -70,8 +69,11 @@ import com.norconex.commons.lang.io.CachedInputStream;
         for (ILinkExtractor extractor : extractors) {
             if (extractor.accepts(reference, ct)) {
                 try {
-                    links.addAll(extractor.extractLinks(is, reference, ct));
-                } catch (IOException e) {
+                    Set<Link> extracted = extractor.extractLinks(is, reference, ct);
+                    if (extracted != null) {
+                        links.addAll(extracted);
+                    }
+                } catch (Exception e) {
                     LOG.error("Could not extract links from: " + reference, e);
                 } finally {
                     is.rewind();

--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/url/impl/GenericLinkExtractor.xsd
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/url/impl/GenericLinkExtractor.xsd
@@ -35,6 +35,13 @@
         </xs:element>
         <xs:element name="extractBetween" type="extractType" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element name="noExtractBetween" type="extractType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="nofollow" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:all>
+              <xs:element name="regexUrl" type="nonEmptyString" minOccurs="0" maxOccurs="unbounded" />
+            </xs:all>
+          </xs:complexType>
+        </xs:element>
       </xs:all>
       <xs:attribute name="class" type="xs:string" use="required"/>
       <xs:attribute name="maxURLLength" type="xs:int"/>


### PR DESCRIPTION
This adds support to be able to entirely bypass link extraction from certain pages (but index the pages themselves).