### PR TITLE
Switch from CookieSpecs.DEFAULT to CookieSpecs.STANDARD

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/client/impl/GenericHttpClientFactory.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/client/impl/GenericHttpClientFactory.java
@@ -300,7 +300,7 @@ public class GenericHttpClientFactory
     private String authWorkstation;
     private String authDomain;
     private boolean authPreemptive;
-    private boolean cookiesDisabled;
+    private String cookieSpec = CookieSpecs.STANDARD;
     private boolean trustAllSSLCertificates;
     private String proxyHost;
     private int proxyPort;
@@ -497,12 +497,8 @@ public class GenericHttpClientFactory
                 .setSocketTimeout(socketTimeout)
                 .setConnectionRequestTimeout(connectionRequestTimeout)
                 .setMaxRedirects(maxRedirects)
-                .setExpectContinueEnabled(expectContinueEnabled);
-        if (cookiesDisabled) {
-            builder.setCookieSpec(CookieSpecs.IGNORE_COOKIES);
-        } else {
-            builder.setCookieSpec(CookieSpecs.DEFAULT);
-        }
+                .setExpectContinueEnabled(expectContinueEnabled)
+                .setCookieSpec(cookieSpec);
         if (maxRedirects <= 0) {
             builder.setRedirectsEnabled(false);
         }
@@ -659,7 +655,11 @@ public class GenericHttpClientFactory
     @Override
     public void loadFromXML(Reader in) {
         XMLConfiguration xml = XMLConfigurationUtil.newXMLConfiguration(in);
-        cookiesDisabled = xml.getBoolean("cookiesDisabled", cookiesDisabled);
+        if (xml.getBoolean("cookiesDisabled", false)) {
+            cookieSpec = CookieSpecs.IGNORE_COOKIES;
+        } else {
+            cookieSpec = xml.getString("cookieSpec", cookieSpec);
+        }
         authMethod = xml.getString("authMethod", authMethod);
         authUsernameField = 
                 xml.getString("authUsernameField", authUsernameField);
@@ -763,7 +763,7 @@ public class GenericHttpClientFactory
             writer.writeStartElement("httpClientFactory");
             writer.writeAttribute("class", getClass().getCanonicalName());
 
-            writer.writeElementBoolean("cookiesDisabled", cookiesDisabled);
+            writer.writeElementString("cookieSpec", cookieSpec);
             writer.writeElementString("authMethod", authMethod);
             writer.writeElementString("authUsername", authUsername);
             writer.writeElementString("authPassword", authPassword);
@@ -1027,14 +1027,27 @@ public class GenericHttpClientFactory
      * @return <code>true</code> if disabled
      */
     public boolean isCookiesDisabled() {
-        return cookiesDisabled;
+        return CookieSpecs.IGNORE_COOKIES.equals(cookieSpec);
     }
     /**
      * Sets whether cookie support is disabled.
      * @param cookiesDisabled <code>true</code> if disabled
      */
     public void setCookiesDisabled(boolean cookiesDisabled) {
-        this.cookiesDisabled = cookiesDisabled;
+        this.cookieSpec = CookieSpecs.IGNORE_COOKIES;
+    }
+    
+    /**
+     * @return the cookieSpec to use as defined in {@link CookieSpecs}
+     */
+    public String getCookieSpec() {
+        return cookieSpec;
+    }
+    /**
+     * @param cookieSpec the cookieSpec to use as defined in {@link CookieSpecs}
+     */
+    public void setCookieSpec(String cookieSpec) {
+        this.cookieSpec = cookieSpec;
     }
 
     /**
@@ -1615,7 +1628,7 @@ public class GenericHttpClientFactory
                 .append(authWorkstation, other.authWorkstation)
                 .append(authDomain, other.authDomain)
                 .append(authPreemptive, other.authPreemptive)
-                .append(cookiesDisabled, other.cookiesDisabled)
+                .append(cookieSpec, other.cookieSpec)
                 .append(trustAllSSLCertificates, other.trustAllSSLCertificates)
                 .append(proxyHost, other.proxyHost)
                 .append(proxyPort, other.proxyPort)
@@ -1660,7 +1673,7 @@ public class GenericHttpClientFactory
                 .append(authWorkstation)
                 .append(authDomain)
                 .append(authPreemptive)
-                .append(cookiesDisabled)
+                .append(cookieSpec)
                 .append(trustAllSSLCertificates)
                 .append(proxyHost)
                 .append(proxyPort)
@@ -1703,7 +1716,7 @@ public class GenericHttpClientFactory
                 .append("authWorkstation", authWorkstation)
                 .append("authDomain", authDomain)
                 .append("authPreemptive", authPreemptive)
-                .append("cookiesDisabled", cookiesDisabled)
+                .append("cookieSpec", cookieSpec)
                 .append("trustAllSSLCertificates", trustAllSSLCertificates)
                 .append("proxyHost", proxyHost)
                 .append("proxyPort", proxyPort)

--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/client/impl/GenericHttpClientFactory.xsd
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/client/impl/GenericHttpClientFactory.xsd
@@ -20,6 +20,16 @@
     <xs:complexType>
       <xs:all>
         <xs:element name="cookiesDisabled" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="cookieSpec" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="default"/>
+              <xs:enumeration value="ignoreCookies"/>
+              <xs:enumeration value="standard"/>
+              <xs:enumeration value="standard-strict"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
         <xs:element name="connectionTimeout" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="socketTimeout" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="connectionRequestTimeout" type="xs:string" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
This fixes warnings like "`Invalid cookie header: "Set-Cookie: last_access=20180919;Path=/;Expires=Wed, 18 Sep 2019 00:00:00 GMT". Invalid 'expires' attribute: Wed, 18 Sep 2019 00:00:00 GMT`"

(that's a valid cookie header according to RFC)

Also allows to go back to the old setting with

```
<httpClientFactory class="com.norconex.collector.http.client.impl.GenericHttpClientFactory">
    <cookieSpec>default</cookieSpec>
</httpClientFactory>
```