### PR TITLE
Don't disable SNI VM-wide, but only for one Crawler

### DIFF
--- a/norconex-collector-http/pom.xml
+++ b/norconex-collector-http/pom.xml
@@ -190,8 +190,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin> 

--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/client/impl/GenericHttpClientFactory.xsd
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/client/impl/GenericHttpClientFactory.xsd
@@ -42,6 +42,7 @@
         <xs:element name="maxConnectionIdleTime" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="maxConnectionInactiveTime" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="trustAllSSLCertificates" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="disableSNI" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
         <xs:element name="sslProtocols" type="nonEmptyString" minOccurs="0" maxOccurs="1"/>
         <xs:element name="proxyHost" type="nonEmptyString" minOccurs="0" maxOccurs="1"/>
         <xs:element name="proxyPort" type="xs:int" minOccurs="0" maxOccurs="1"/>

--- a/norconex-collector-http/src/test/resources/validation/collector-http-full.xml
+++ b/norconex-collector-http/src/test/resources/validation/collector-http-full.xml
@@ -85,6 +85,7 @@
       <maxConnectionIdleTime>7</maxConnectionIdleTime>
       <maxConnectionInactiveTime>8</maxConnectionInactiveTime>
       <trustAllSSLCertificates>true</trustAllSSLCertificates>
+      <disableSNI>true</disableSNI>
       <sslProtocols>item1,item2</sslProtocols>
       <proxyHost>host</proxyHost>
       <proxyPort>9</proxyPort>


### PR DESCRIPTION
In java 7 SNI only can be disabled by setting a system property that affects the entire JVM as explained in 
http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7127374 
In response to https://github.com/Norconex/collector-http/issues/181 you included setting this system property when the trustAllSSLCertificates will be set.

But this has side effects, if you have a Collector with many Crawlers for different SSL-sites, where some have untrusted certificates, other have correct SNI server settings and again others have wrong virtual host settings that lead to the SSLHandshakeException due to the unknown_server_name .

Starting from Java 8 SNI can be disabled on the SSLSocketFactory by setting an empty list of servernames during socket preparation.
I found an outline of this solution here:
https://github.com/lightbody/browsermob-proxy/issues/117#issuecomment-141363454

This change requests updates to Java 8, introduces a configuration option to disable SNI and only disables it in the SSLSocketFactory  when preparing the Socket.
 
SNI configuration is decoupled from trustAllSSLCertificates.

I don't know, if you still have to support Java 7 ? Oracle support for Java 7 already ended 2015 ...

But having SNI control on a per-crawler configuration is very important and necessary for our use of Norconex, where we have many Crawlers for different site.