### PR TITLE
Fix quoted mediatype from content type

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/pipeline/importer/HttpImporterPipelineUtil.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/pipeline/importer/HttpImporterPipelineUtil.java
@@ -14,14 +14,6 @@
  */
 package com.norconex.collector.http.pipeline.importer;
 
-import java.io.IOException;
-import java.util.Arrays;
-
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-
 import com.norconex.collector.core.CollectorException;
 import com.norconex.collector.core.data.store.ICrawlDataStore;
 import com.norconex.collector.http.crawler.HttpCrawlerEvent;
@@ -35,6 +27,14 @@ import com.norconex.collector.http.pipeline.queue.HttpQueuePipelineContext;
 import com.norconex.collector.http.url.ICanonicalLinkDetector;
 import com.norconex.collector.http.url.IURLNormalizer;
 import com.norconex.commons.lang.file.ContentType;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * @author Pascal Essiembre
@@ -79,13 +79,17 @@ import com.norconex.commons.lang.file.ContentType;
             }
         }
 
-        if (StringUtils.isBlank(colCT)) {
-            String ct = StringUtils.trimToNull(
-                    StringUtils.substringBefore(httpCT, ";"));
-            if (ct != null) {
-                meta.addString(HttpMetadata.COLLECTOR_CONTENT_TYPE, ct);
+        if (StringUtils.isNotBlank(httpCT)) {
+            // delegate parsing of content-type honoring various forms
+            // https://tools.ietf.org/html/rfc7231#section-3.1.1
+            org.apache.http.entity.ContentType parsedCT = org.apache.http.entity.ContentType.parse(httpCT);
+
+            if (StringUtils.isBlank(colCT)) {
+                String ct = parsedCT.getMimeType();
+                if (ct != null) {
+                    meta.addString(HttpMetadata.COLLECTOR_CONTENT_TYPE, ct);
+                }
             }
-        }
 
             if (StringUtils.isBlank(colCE)) {
                 // Grab charset form HTTP Content-Type

--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/pipeline/importer/HttpImporterPipelineUtil.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/pipeline/importer/HttpImporterPipelineUtil.java
@@ -87,16 +87,12 @@ import com.norconex.commons.lang.file.ContentType;
             }
         }
 
-        if (StringUtils.isBlank(colCE)) {
-            // Grab charset form HTTP Content-Type
-            String ce = null;
-            if (httpCT != null && httpCT.contains("charset")) {
-                ce = StringUtils.trimToNull(
-                        StringUtils.substringAfter(httpCT, "charset="));
-            }
-
-            if (ce != null) {
-                meta.addString(HttpMetadata.COLLECTOR_CONTENT_ENCODING, ce);
+            if (StringUtils.isBlank(colCE)) {
+                // Grab charset form HTTP Content-Type
+                String ce = Objects.toString(parsedCT.getCharset(), null);
+                if (ce != null) {
+                    meta.addString(HttpMetadata.COLLECTOR_CONTENT_ENCODING, ce);
+                }
             }
         }
     }

--- a/norconex-collector-http/src/test/java/com/norconex/collector/http/pipeline/importer/HttpImporterPipelineUtilTest.java
+++ b/norconex-collector-http/src/test/java/com/norconex/collector/http/pipeline/importer/HttpImporterPipelineUtilTest.java
@@ -1,0 +1,87 @@
+package com.norconex.collector.http.pipeline.importer;
+
+import com.norconex.collector.http.doc.HttpMetadata;
+import com.norconex.commons.lang.map.Properties;
+import org.junit.Test;
+
+import static com.norconex.collector.http.doc.HttpMetadata.*;
+import static org.junit.Assert.*;
+
+public class HttpImporterPipelineUtilTest {
+
+    @Test
+    public void enhanceHTTPHeaders() {
+
+        assertEnhancedHeaders("text/html; charset=UTF-8",
+                null, null,
+                "text/html", "UTF-8");
+
+        assertEnhancedHeaders("text/html; charset=UTF-8",
+                "our/custom", null,
+                "our/custom", "UTF-8");
+
+        assertEnhancedHeaders("text/html; charset=utf-8",
+                null, "iso-8859-4",
+                "text/html", "iso-8859-4");
+
+        assertEnhancedHeaders("text/html; charset=",
+                null, null,
+                "text/html", null);
+
+        assertEnhancedHeaders("text/html;",
+                null, null,
+                "text/html", null);
+
+        assertEnhancedHeaders("text/html",
+                null, null,
+                "text/html", null);
+
+        assertEnhancedHeaders("",
+                null, null,
+                null, null);
+
+        assertEnhancedHeaders(null,
+                null, null,
+                null, null);
+
+        // alternative allowed versions for content-type:
+        // https://tools.ietf.org/html/rfc7231#section-3.1.1
+
+        assertEnhancedHeaders("text/html;charset=UTF-8",
+                null, null,
+                "text/html", "UTF-8");
+
+        assertEnhancedHeaders("text/html;charset=\"UTF-8\"",
+                null, null,
+                "text/html", "UTF-8");
+
+        assertEnhancedHeaders("text/html;charset=utf-8",
+                null, null,
+                "text/html", "UTF-8");
+
+        assertEnhancedHeaders("text/html;charset=\"utf-8\"",
+                null, null,
+                "text/html", "UTF-8");
+
+    }
+
+    private void assertEnhancedHeaders(String httpContentType,
+                                       String inputCollectorContentType, String inputCollectorEncoding,
+                                       String expectedCollectorContentType, String expectedCollectorContentEncoding) {
+        Properties metadata = new Properties();
+
+        if (httpContentType != null) {
+            metadata.addString(HTTP_CONTENT_TYPE, httpContentType);
+        }
+        if (inputCollectorContentType != null) {
+            metadata.addString(COLLECTOR_CONTENT_TYPE, inputCollectorContentType);
+        }
+        if (inputCollectorEncoding != null) {
+            metadata.addString(COLLECTOR_CONTENT_ENCODING, inputCollectorEncoding);
+        }
+        HttpImporterPipelineUtil.enhanceHTTPHeaders(new HttpMetadata(metadata));
+
+        assertEquals(expectedCollectorContentType, metadata.getString(COLLECTOR_CONTENT_TYPE));
+        assertEquals(expectedCollectorContentEncoding, metadata.getString(COLLECTOR_CONTENT_ENCODING));
+    }
+}


### PR DESCRIPTION
For some sites we were getting the following errors during crawling:
java.nio.charset.IllegalCharsetNameException: "UTF-8"

The reason is that these sites, for example facebook, are sending the charset in the content-type within quotes, like
content-type: text/html; charset="UTF-8"

When creating a Java Charset from the String ""UTF-8"" the exception is thrown.

The RFC states, that all forms are correct, with or without quotes:
https://tools.ietf.org/html/rfc7231#section-3.1.1

The same issue also is discussed here:
https://github.com/crystal-lang/crystal/issues/6353

I pushed a fix, that delegates parsing of the content-type header to httpclient, that handles all the forms correctly and added a JUnit-Test that checked the old behavior (null values) and the new one with the supported forms