### PR TITLE
Support non-standard canonical expression

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/url/impl/GenericCanonicalLinkDetector.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/url/impl/GenericCanonicalLinkDetector.java
@@ -142,6 +142,9 @@ public class GenericCanonicalLinkDetector
     private static final Pattern PATTERN_REL =
             Pattern.compile("\\srel\\s*=\\s*([\"'])\\s*canonical\\s*\\1",
                     Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_PROPERTY =
+            Pattern.compile("\\sproperty\\s*=\\s*([\"'])\\s*canonical\\s*\\1",
+                    Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
     private static final Pattern PATTERN_URL =
             Pattern.compile("\\shref\\s*=\\s*([\"'])\\s*(.*?)\\s*\\1",
                     Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
@@ -173,8 +176,12 @@ public class GenericCanonicalLinkDetector
                     nameMatcher.find();
                     String name = nameMatcher.group(
                             PATTERN_NAME_GROUP).toLowerCase();
-                    if ("link".equalsIgnoreCase(name)
-                            && PATTERN_REL.matcher(tag).find()) {
+                    if ( ("link".equalsIgnoreCase(name)
+                            && PATTERN_REL.matcher(tag).find() )
+                        ||
+                        ("meta".equalsIgnoreCase(name)
+                                && PATTERN_PROPERTY.matcher(tag).find() )
+                        ) {
                         Matcher urlMatcher = PATTERN_URL.matcher(tag);
                         if (urlMatcher.find()) {
                             return toAbsolute(reference,

--- a/norconex-collector-http/src/test/java/com/norconex/collector/http/url/impl/GenericCanonicalLinkDetectorTest.java
+++ b/norconex-collector-http/src/test/java/com/norconex/collector/http/url/impl/GenericCanonicalLinkDetectorTest.java
@@ -79,12 +79,20 @@ public class GenericCanonicalLinkDetectorTest {
         String canonURL = "http://www.example.com/canonical.pdf";
         String url = null;
 
-        // Valid link tag
-        String contentValid = "<html><head><title>Test</title>\n"
+        // Valid link tag (meta)
+        String contentValidMeta = "<html><head><title>Test</title>\n"
+                + "<meta property=\"canonical\"\n href=\"\n" + canonURL +  "\" />\n"
+                + "</head><body>Nothing of interest in body</body></html>";
+        url = d.detectFromContent(reference,  new ByteArrayInputStream(
+                contentValidMeta.getBytes()), ContentType.HTML);
+        Assert.assertEquals("Invalid <link> form <head>", canonURL, url);
+
+        // Valid link tag (link)
+        String contentValidLink = "<html><head><title>Test</title>\n"
                 + "<link rel=\"canonical\"\n href=\"\n" + canonURL +  "\" />\n"
                 + "</head><body>Nothing of interest in body</body></html>";
         url = d.detectFromContent(reference,  new ByteArrayInputStream(
-                contentValid.getBytes()), ContentType.HTML);
+                contentValidLink.getBytes()), ContentType.HTML);
         Assert.assertEquals("Invalid <link> form <head>", canonURL, url);
 
         // Invalid location for link tag


### PR DESCRIPTION
Addresses #697
Some sites use :
`<meta property="canonical" href="...">`