### PR TITLE
Correct authFormParams parameter loading

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/client/impl/GenericHttpClientFactory.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/client/impl/GenericHttpClientFactory.java
@@ -730,7 +730,7 @@ public class GenericHttpClientFactory
         if (!xmlAuthFormParams.isEmpty()) {
             authFormParams.clear();
             for (HierarchicalConfiguration xmlParam : xmlAuthFormParams) {
-                requestHeaders.put(
+                authFormParams.put(
                         xmlParam.getString("[@name]"),
                         xmlParam.getString(""));
             }


### PR DESCRIPTION
This is relevant to https://github.com/Norconex/collector-http/issues/434
I couldn't get formAuthentication to pass additional form params correctly

I made a simple script containing 
```
<?php var_dump($_POST); die(); ?>
```

```
website: 2021-01-14 18:50:28 INFO - Performing FORM authentication at "https://example.com/test.php" (username=username; password=*****)
website: 2021-01-14 18:50:28 INFO - Authentication status: HTTP/1.1 200 OK
website: 2021-01-14 18:50:28 DEBUG - Authentication response:
array(2) {
["username"]=>
string(8) "username"
["pass"]=>
string(8) "password"
}
```

I've tried both 2.8.1 and 2.9.1 but the authFormParams field doesn't seem to do anything

my config looks like
```
 <httpClientFactory class="com.norconex.collector.http.client.impl.GenericHttpClientFactory">
        <cookiesDisabled>false</cookiesDisabled>
        <maxRedirects>5</maxRedirects>
        <connectionTimeout>60000</connectionTimeout>
        <authFormCharset>UTF-8</authFormCharset>
        <authMethod>form</authMethod>
        <authURL>https://example.com/test.php</authURL>
        <authUsername>username</authUsername>
        <authPassword>password</authPassword>
        <authUsernameField>username</authUsernameField>
        <authPasswordField>pass</authPasswordField>
        <authFormParams>
          <param name="test">test</param>
        </authFormParams>
      </httpClientFactory>
 ```
 
 After this change my response looks like
 ```
 website: 2021-01-14 19:32:29 DEBUG - Authentication response:
array(3) {
  ["username"]=>
  string(8) "username"
  ["pass"]=>
  string(8) "password"
  ["test"]=>
  string(4) "test"
}
```