### PR TITLE
Use filenames with correct case

### DIFF
--- a/crawler/web/src/test/java/com/norconex/crawler/web/link/impl/XmlFeedLinkExtractorTest.java
+++ b/crawler/web/src/test/java/com/norconex/crawler/web/link/impl/XmlFeedLinkExtractorTest.java
@@ -40,7 +40,7 @@ class XmlFeedLinkExtractorTest {
     void testAtomLinkExtraction()  throws IOException {
         var baseURL = "http://www.example.com/";
         var baseDir = baseURL + "test/";
-        var docURL = baseDir + "XmlFeedLinkExtractorTest.atom";
+        var docURL = baseDir + "XMLFeedLinkExtractorTest.atom";
 
         var extractor = new XmlFeedLinkExtractor();
 
@@ -52,7 +52,7 @@ class XmlFeedLinkExtractorTest {
         };
 
         InputStream is = IOUtils.buffer(getClass().getResourceAsStream(
-                "XmlFeedLinkExtractorTest.atom"));
+                "XMLFeedLinkExtractorTest.atom"));
 
         var ct = ContentTypeDetector.detect(is);
 
@@ -75,7 +75,7 @@ class XmlFeedLinkExtractorTest {
     void testRSSLinkExtraction()  throws IOException {
         var baseURL = "http://www.example.com/";
         var baseDir = baseURL + "test/";
-        var docURL = baseDir + "XmlFeedLinkExtractorTest.rss";
+        var docURL = baseDir + "XMLFeedLinkExtractorTest.rss";
 
         var extractor = new XmlFeedLinkExtractor();
 
@@ -87,7 +87,7 @@ class XmlFeedLinkExtractorTest {
         };
 
         InputStream is = IOUtils.buffer(getClass().getResourceAsStream(
-                "XmlFeedLinkExtractorTest.rss"));
+                "XMLFeedLinkExtractorTest.rss"));
 
         var ct = ContentTypeDetector.detect(is);
 


### PR DESCRIPTION
Fix for getResourceAsStream() failing in GitHub.